### PR TITLE
Don't precompute ZIP ranges; test them on demand

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,58 +1,56 @@
 
 'use strict'
 
-const range = (min, max) => [...Array(max - min + 1).keys()].map(i => String(i + min))
-
-const al = range(35004, 36925); // alabama
-const ak = range(99501, 99950); // alaska
-const az = range(85001, 86556); // arizona
-const ar = range(71601, 72959); // arkansas
-const ca = range(90001, 96162); // california
-const co = range(80001, 81658); // colorado
-const ct = range(6001, 6928);  // connecticut
-const de = range(19701, 19980); // delaware
-const fl = range(32003, 34997); // florida
-const ga = range(30002, 39901); // georgia
-const hi = range(96701, 96898); // hawaii
-const id = range(83201, 83877); // idaho
-const il = range(60001, 62999); // illinois;
-const ind = range(46001, 47997); // indiana
-const ia = range(50001, 52809); // iowa
-const ks = range(66002, 67954); // kansas
-const ky = range(40003, 42788); // kentucky
-const la = range(70001, 71497); // louisiana
-const me = range(3901, 4992); // maine
-const md = range(20588, 21930); // maryland
-const ma = range(1001, 5544); // massachusetts
-const mi = range(48001, 49971); // michigan
-const mn = range(55001, 56763); // minnesota
-const ms = range(38601, 39776); // mississippi
-const mo = range(63001, 65899); // missouri
-const mt = range(59001, 59937); // montana
-const ne = range(68001, 69367); // nebraska
-const nv = range(88901, 89883); // nevada
-const nh = range(3031, 3897); // new hampshire
-const nj = range(7001, 8989); // new jersey
-const nm = range(87001, 88439); // new mexico
-const ny = range(501, 14925); // new york
-const nc = range(27006, 28909); // north carolina
-const nd = range(58001, 58856); // north dakota
-const oh = range(43001, 45999); // ohio
-const ok = range(73001, 74966); // oklahoma
-const or = range(97001, 97920); // oregon
-const pa = range(15001, 19640); // pennsylvania
-const ri = range(2801, 2940); // rhode island
-const sc = range(29001, 29945); // south carolina
-const sd = range(57001, 57799); // south dakota
-const tn = range(37010, 38589); // tennessee
-const tx = range(73301, 88595); // texas
-const ut = range(84001, 84791); // utah
-const vt = range(5001, 5907); // vermont
-const va = range(20101, 24658); // virginia
-const wa = range(98001, 99403); // washington
-const wv = range(24701, 26886); // west virginia
-const wi = range(53001, 54990); // wisconsin
-const wy = range(82001, 83414); // wyoming
+const al = [35004, 36925]; // alabama
+const ak = [99501, 99950]; // alaska
+const az = [85001, 86556]; // arizona
+const ar = [71601, 72959]; // arkansas
+const ca = [90001, 96162]; // california
+const co = [80001, 81658]; // colorado
+const ct = [6001, 6928];  // connecticut
+const de = [19701, 19980]; // delaware
+const fl = [32003, 34997]; // florida
+const ga = [30002, 39901]; // georgia
+const hi = [96701, 96898]; // hawaii
+const id = [83201, 83877]; // idaho
+const il = [60001, 62999]; // illinois;
+const ind = [46001, 47997]; // indiana
+const ia = [50001, 52809]; // iowa
+const ks = [66002, 67954]; // kansas
+const ky = [40003, 42788]; // kentucky
+const la = [70001, 71497]; // louisiana
+const me = [3901, 4992]; // maine
+const md = [20588, 21930]; // maryland
+const ma = [1001, 5544]; // massachusetts
+const mi = [48001, 49971]; // michigan
+const mn = [55001, 56763]; // minnesota
+const ms = [38601, 39776]; // mississippi
+const mo = [63001, 65899]; // missouri
+const mt = [59001, 59937]; // montana
+const ne = [68001, 69367]; // nebraska
+const nv = [88901, 89883]; // nevada
+const nh = [3031, 3897]; // new hampshire
+const nj = [7001, 8989]; // new jersey
+const nm = [87001, 88439]; // new mexico
+const ny = [501, 14925]; // new york
+const nc = [27006, 28909]; // north carolina
+const nd = [58001, 58856]; // north dakota
+const oh = [43001, 45999]; // ohio
+const ok = [73001, 74966]; // oklahoma
+const or = [97001, 97920]; // oregon
+const pa = [15001, 19640]; // pennsylvania
+const ri = [2801, 2940]; // rhode island
+const sc = [29001, 29945]; // south carolina
+const sd = [57001, 57799]; // south dakota
+const tn = [37010, 38589]; // tennessee
+const tx = [73301, 88595]; // texas
+const ut = [84001, 84791]; // utah
+const vt = [5001, 5907]; // vermont
+const va = [20101, 24658]; // virginia
+const wa = [98001, 99403]; // washington
+const wv = [24701, 26886]; // west virginia
+const wi = [53001, 54990]; // wisconsin
+const wy = [82001, 83414]; // wyoming
 
 
 const zipCodes = {
@@ -161,16 +159,12 @@ const zipCodes = {
 exports.validate = function validate(province, zip) {
   const prefix = zipCodes[province.toLowerCase()];
 
-  if (prefix) {
-    if (typeof(prefix) == 'object') {
-
-      if (prefix.includes(String(zip))) {
-        return true
-      }
-      else {
-        return false
-      }
-
+  if (prefix && typeof prefix === "object") {
+    const intZip = parseInt(String(zip).split(/[^\d]/)[0], 10);
+    if (intZip >= prefix[0] && intZip <= prefix[1]) {
+      return true;
     }
   }
+
+  return false;
 }

--- a/test/zip-code.spec.js
+++ b/test/zip-code.spec.js
@@ -452,4 +452,9 @@ describe('USA postal code', () => {
             expect(zipCodes.validate('WY', '89999')).toBe(false);
         });
     });
+    describe('ZIP+4', ()=> {
+        it('should validate zip code', () => {
+            expect(zipCodes.validate('PA', '16735-1309')).toBe(true);
+        });
+    });
 });


### PR DESCRIPTION
Rather than to create huge arrays of ZIP codes that might never get used, lets compute the ZIP as an integer and do a fast arithmetic comparison.

Bonus: this will now validate ZIP+4 codes, such as PA 16735-1309.

#### Test plan

```shell
yarn test
```